### PR TITLE
Sprint 5: agent rules (Claude Code, Cursor, Roo) — closes #5

### DIFF
--- a/.claude/commands/add-rule.md
+++ b/.claude/commands/add-rule.md
@@ -1,0 +1,29 @@
+Добавь правило для нового компонента дизайн-системы.
+
+Аргументы: $ARGUMENTS
+(ожидается: название компонента и/или описание его пропов и вариантов)
+
+## Твои шаги
+
+1. **Прочитай формат** — `rules/README.md` и любой существующий файл из `rules/` для примера.
+
+2. **Создай файл** `rules/<component-name>.rules.json`:
+   - `figmaName` — точное имя в Figma (спроси у пользователя если неизвестно)
+   - `component` — имя React-компонента
+   - `importPath` — путь импорта (primereact/... или uikit/...)
+   - `props` — маппинг Figma props → React props
+   - `variants` — маппинг Figma variants → React className/props
+
+3. **Валидируй:**
+   ```bash
+   node renderer/src/validate-rules.js rules/<component-name>.rules.json
+   ```
+   Исправь ошибки если есть.
+
+4. **Пересобери bundle:**
+   ```bash
+   node scripts/build-rules-bundle.js
+   ```
+
+5. Сообщи пользователю сколько компонентов теперь в rules/ и что нужно сделать дальше
+   (обновить примеры, если компонент используется в существующих страницах).

--- a/.claude/commands/gen-page.md
+++ b/.claude/commands/gen-page.md
@@ -1,0 +1,37 @@
+Сгенерируй страницу по дизайн-спеке для этого репозитория.
+
+Аргументы: $ARGUMENTS
+(ожидается: <figma-node-id или описание> --route /путь --out src/pages/ИмяСтраницы.tsx)
+
+## Твои шаги
+
+1. **Прочитай контекст** — прочитай эти файлы:
+   - `prompts/rules-bundle.md` — все доступные компоненты
+   - `schema/page-spec.schema.json` — схема валидации
+   - `prompts/system.md` — правила генерации
+
+2. **Получи дизайн** — если передан Figma node ID, вызови Figma MCP `get_design_context`.
+   Если нет — попроси пользователя описать страницу или вставить данные из Figma.
+
+3. **Сгенерируй page-spec.json** строго по схеме и правилам из rules-bundle.
+   - Только компоненты из rules/
+   - Только разрешённые className
+   - Не придумывай importPath
+
+4. **Сохрани spec** во временный файл `/tmp/spec-<name>.json`
+
+5. **Валидируй:**
+   ```bash
+   node renderer/src/index.js --validate /tmp/spec-<name>.json
+   ```
+   Если ошибки — исправь spec и повтори валидацию.
+
+6. **Генерируй TSX:**
+   ```bash
+   node renderer/src/index.js --input /tmp/spec-<name>.json --out <out-dir>
+   ```
+
+7. **Сохрани spec** в `examples/<name>.json` для истории.
+
+8. Покажи пользователю путь к сгенерированному файлу и краткое резюме:
+   сколько компонентов, какие хуки использованы, есть ли `_comment` с непокрытыми элементами.

--- a/.cursor/rules/add-rule.mdc
+++ b/.cursor/rules/add-rule.mdc
@@ -1,0 +1,46 @@
+---
+description: Добавление нового правила для компонента дизайн-системы
+globs: rules/**
+alwaysApply: false
+---
+
+# Добавление правила для нового компонента
+
+Применяй когда пользователь хочет добавить поддержку нового компонента в pipeline.
+
+## Алгоритм
+
+### 1. Прочитай формат
+- `rules/README.md` — формат и примеры
+- Любой файл из `rules/` — для референса
+
+### 2. Создай файл `rules/<name>.rules.json`
+
+Обязательные поля:
+```json
+{
+  "version": "1",
+  "components": [{
+    "figmaName": "ComponentGroup/ComponentName",
+    "component": "ReactComponentName",
+    "importPath": "primereact/packagename",
+    "props": { "figmaProp": { "mapTo": "reactProp" } },
+    "variants": { "Variant=value": { "className": "p-class-name" } }
+  }]
+}
+```
+
+Для HTML-элементов вместо `component`/`importPath` используй `element` + `className`.
+
+### 3. Валидируй
+```bash
+node renderer/src/validate-rules.js rules/<name>.rules.json
+```
+
+### 4. Пересобери bundle
+```bash
+node scripts/build-rules-bundle.js
+```
+
+### 5. Обнови README
+Добавь строку в таблицу в `rules/README.md`.

--- a/.cursor/rules/gen-page.mdc
+++ b/.cursor/rules/gen-page.mdc
@@ -1,0 +1,60 @@
+---
+description: Генерация страницы из Figma-макета в .tsx через page-spec pipeline
+globs:
+alwaysApply: false
+---
+
+# Генерация страницы: Figma → page-spec.json → .tsx
+
+Применяй эти инструкции когда пользователь просит сгенерировать страницу, компонент или экран по Figma-макету.
+
+## Контекст репозитория
+
+Этот репо реализует pipeline: **Figma → page-spec.json → renderer → .tsx**
+- Компоненты описаны в `rules/*.rules.json`
+- Все правила собраны в `prompts/rules-bundle.md`
+- Renderer: `node renderer/src/index.js`
+
+## Алгоритм
+
+### 1. Загрузи контекст
+Прочитай перед генерацией:
+- `prompts/rules-bundle.md` — список всех доступных компонентов и их пропов
+- `schema/page-spec.schema.json` — схема валидации
+- `prompts/system.md` — правила генерации
+
+### 2. Получи данные из Figma
+Если есть Figma MCP — вызови `get_design_context` для нужного node.
+Иначе — попроси пользователя вставить данные из Figma или описать экран.
+
+### 3. Сгенерируй page-spec.json
+
+**Обязательные правила:**
+- Только компоненты из `rules/` — никаких выдуманных
+- `importPath` — строго из правил, не придумывать
+- `className` — только из разрешённого списка в `prompts/system.md`
+- Если компонент не покрыт — добавить `_comment`, использовать ближайший аналог
+- `imports` содержит только то, что реально используется в `tree`
+
+### 4. Валидируй
+```bash
+node renderer/src/index.js --validate /tmp/spec.json
+```
+При ошибках — исправь spec и повтори. Не продолжай без зелёного ✅.
+
+### 5. Генерируй TSX
+```bash
+node renderer/src/index.js --input /tmp/spec.json --out <целевая папка>
+```
+
+### 6. Сохрани spec
+```bash
+cp /tmp/spec.json examples/<name>.json
+```
+
+## Итог для пользователя
+
+Покажи:
+- путь к `.tsx` файлу
+- список использованных компонентов
+- список `_comment` если есть непокрытые элементы (→ нужно добавить правило)

--- a/.roo/rules/add-rule.md
+++ b/.roo/rules/add-rule.md
@@ -1,0 +1,40 @@
+# Добавление правила для нового компонента
+
+Применяй когда пользователь хочет добавить компонент в pipeline.
+
+## Шаги
+
+**1. Прочитай формат:** `rules/README.md` + любой файл из `rules/`
+
+**2. Создай `rules/<name>.rules.json`**
+
+React-компонент:
+```json
+{
+  "version": "1",
+  "components": [{
+    "figmaName": "Group/Name",
+    "component": "ReactName",
+    "importPath": "primereact/package",
+    "props": { "figmaProp": { "mapTo": "reactProp" } },
+    "variants": { "Prop=Value": { "className": "p-class" } }
+  }]
+}
+```
+
+HTML-элемент (без импорта):
+```json
+{ "figmaName": "Layout/Card", "element": "div", "className": "card" }
+```
+
+**3. Валидируй**
+```bash
+node renderer/src/validate-rules.js rules/<name>.rules.json
+```
+
+**4. Пересобери bundle**
+```bash
+node scripts/build-rules-bundle.js
+```
+
+**5. Обнови `rules/README.md`** — добавь строку в таблицу.

--- a/.roo/rules/gen-page.md
+++ b/.roo/rules/gen-page.md
@@ -1,0 +1,50 @@
+# Генерация страницы: Figma → page-spec.json → .tsx
+
+Применяй эти инструкции когда пользователь просит сгенерировать страницу или экран по Figma-макету.
+
+## Контекст
+
+Pipeline этого репо: **Figma → page-spec.json → renderer → .tsx**
+- Правила компонентов: `rules/*.rules.json`
+- Все правила в одном файле: `prompts/rules-bundle.md`
+- CLI рендерера: `node renderer/src/index.js`
+
+## Шаги
+
+**1. Прочитай перед генерацией:**
+```
+prompts/rules-bundle.md        ← все компоненты и их пропы
+schema/page-spec.schema.json   ← схема
+prompts/system.md              ← правила генерации
+```
+
+**2. Получи данные дизайна**
+
+Если доступен Figma MCP — `get_design_context(nodeId)`.
+Если нет — попроси пользователя описать экран или вставить данные.
+
+**3. Сгенерируй page-spec.json**
+
+Жёсткие ограничения:
+- Только компоненты из `rules/` — не придумывать новые
+- `importPath` — точно из правил
+- `className` — только из разрешённого списка (`prompts/system.md`)
+- Непокрытые компоненты → `_comment`, ближайший аналог
+
+**4. Валидируй**
+```bash
+node renderer/src/index.js --validate /tmp/spec.json
+```
+Ошибки → исправь → повтори. Не двигайся дальше без ✅.
+
+**5. Сгенерируй TSX**
+```bash
+node renderer/src/index.js --input /tmp/spec.json --out <dir>
+```
+
+**6. Сохрани spec**
+```bash
+cp /tmp/spec.json examples/<name>.json
+```
+
+**7. Покажи итог:** путь к файлу, список компонентов, `_comment` если есть.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md — ds_spec
+
+Инструкция для любого AI-агента работающего с этим репозиторием.
+
+## Что это за репо
+
+Pipeline: **Figma → page-spec.json → renderer → .tsx**
+
+Дизайнер работает через компоненты дизайн-системы (PrimeReact + uikit).
+LLM генерирует `page-spec.json` строго по правилам из `rules/`.
+Renderer детерминированно превращает spec в TypeScript.
+
+## Ключевые файлы
+
+| Файл/папка | Роль |
+|---|---|
+| `rules/*.rules.json` | Маппинг Figma-компонентов → React (источник истины) |
+| `prompts/rules-bundle.md` | Все rules в одном файле — подкладывать в контекст LLM |
+| `prompts/system.md` | System prompt для генерации page-spec |
+| `schema/page-spec.schema.json` | JSON Schema — валидация spec |
+| `renderer/src/index.js` | CLI: spec → .tsx |
+| `examples/*.json` | Готовые примеры page-spec |
+
+## Workflow 1: Сгенерировать страницу
+
+**Вход:** Figma node или текстовое описание + маршрут + путь выходного файла.
+
+```
+1. Прочитать prompts/rules-bundle.md          ← доступные компоненты
+2. Прочитать schema/page-spec.schema.json     ← структура spec
+3. Прочитать prompts/system.md                ← правила генерации
+4. Если есть Figma MCP → get_design_context(nodeId)
+5. Сгенерировать page-spec.json по схеме
+6. Валидировать: node renderer/src/index.js --validate <spec>
+7. Если ошибки → исправить spec и повторить шаг 6
+8. Генерировать: node renderer/src/index.js --input <spec> --out <dir>
+9. Сохранить spec в examples/<name>.json
+```
+
+**Нельзя:** придумывать компоненты, importPath или className не из rules/.
+**Если компонент не покрыт правилом:** добавить `_comment` и использовать ближайший аналог.
+
+## Workflow 2: Добавить правило для нового компонента
+
+```
+1. Создать rules/<name>.rules.json по формату из rules/README.md
+2. Валидировать: node renderer/src/validate-rules.js rules/<name>.rules.json
+3. Пересобрать bundle: node scripts/build-rules-bundle.js
+4. Добавить пример использования в examples/ или обновить существующий
+```
+
+## Workflow 3: Проверить покрытие
+
+```bash
+node renderer/src/validate-rules.js rules/   # все файлы + счётчик компонентов
+node scripts/test-renderer.js                # E2E: examples/ → golden/
+```
+
+## Формат page-spec.json (кратко)
+
+```jsonc
+{
+  "version": "1",
+  "page": { "id": "myPage", "route": "/my-page", "file": "src/pages/MyPage.tsx" },
+  "imports": ["import React, { useState } from 'react';", "..."],
+  "state": [{ "name": "query", "type": "string", "initial": "''" }],
+  "refs": [{ "name": "menuRef", "type": "Menu" }],
+  "derived": [{ "name": "filtered", "deps": ["items","query"], "logic": "..." }],
+  "callbacks": [{ "name": "handleSave", "params": "", "deps": [], "body": "..." }],
+  "effects": [{ "deps": [], "body": "loadData();" }],
+  "data": { "ITEMS": [...] },
+  "tree": { "type": "component", "component": "AppLayout", "children": [...] }
+}
+```
+
+## Установка зависимостей (если нужно)
+
+```bash
+cd renderer && npm install
+```


### PR DESCRIPTION
Closes #5

## Что добавлено

**`AGENTS.md`** — универсальная инструкция для любого агента/LLM. Описывает оба workflow: генерация страницы и добавление правила.

**Claude Code** (`.claude/commands/`):
- `/gen-page` — Figma node → spec → validate → .tsx за один запрос
- `/add-rule` — описание компонента → rules.json → bundle rebuild

**Cursor** (`.cursor/rules/`):
- `gen-page.mdc` — активируется когда просят сгенерировать страницу
- `add-rule.mdc` — активируется при работе с `rules/**`

**Roo Code** (`.roo/rules/`):
- `gen-page.md` — тот же workflow, работает с любым LLM включая локальные
- `add-rule.md` — добавление правила

## Ключевое

Все инструменты вызывают одни и те же скрипты — никакой привязки к вендору LLM.